### PR TITLE
feat: add configuration system

### DIFF
--- a/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
@@ -1,17 +1,34 @@
 package com.bteconosur.core;
 
+import com.bteconosur.core.config.ConfigFile;
+import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
 
 public final class BteConoSurCore extends JavaPlugin {
 
     @Override
     public void onEnable() {
         // Plugin startup logic
-
+        try {
+            ConfigFile.saveDefaultConfig();
+        } catch (IOException | InvalidConfigurationException e) {
+            this.disablePlugin();
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    public static BteConoSurCore getPlugin() {
+        return JavaPlugin.getPlugin(BteConoSurCore.class);
+    }
+
+    public void disablePlugin() {
+        this.getServer().getPluginManager().disablePlugin(this);
     }
 }

--- a/1_20_core/src/main/java/com/bteconosur/core/config/ConfigFile.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/config/ConfigFile.java
@@ -1,0 +1,42 @@
+package com.bteconosur.core.config;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.io.IOException;
+
+public enum ConfigFile {
+    CONFIG,
+    LANG;
+
+    private ConfigHandler configHandler;
+    private final String name = name().toLowerCase() + ".yml";
+
+    /**
+     * Genera todos los archivos de configuración por defecto.
+     * @throws IOException Si el archivo no se puede crear.
+     * @throws InvalidConfigurationException Si el contenido del archivo es inválido.
+     */
+    public static void saveDefaultConfig() throws IOException, InvalidConfigurationException {
+        for (ConfigFile configFile : values()) {
+            configFile.configHandler = new ConfigHandler(configFile.name);
+        }
+    }
+
+    /**
+     * Recarga todos los archivos de configuración.
+     */
+    public static void reloadConfig() {
+        for (ConfigFile configFile : values()) {
+            configFile.getConfigHandler().reload();
+        }
+    }
+
+    public FileConfiguration getConfig() {
+        return configHandler.getFileConfiguration();
+    }
+
+    private ConfigHandler getConfigHandler() {
+        return configHandler;
+    }
+}

--- a/1_20_core/src/main/java/com/bteconosur/core/config/ConfigHandler.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/config/ConfigHandler.java
@@ -1,0 +1,64 @@
+package com.bteconosur.core.config;
+
+import com.bteconosur.core.BteConoSurCore;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ConfigHandler {
+    private FileConfiguration fileConfiguration;
+    private final BteConoSurCore plugin = BteConoSurCore.getPlugin();
+    private File file;
+    private final String fileName;
+
+    public ConfigHandler(String fileName) throws IOException, InvalidConfigurationException {
+        this.fileName = fileName;
+        this.register();
+    }
+
+    /**
+     * Crea un archivo de configuración si no existe y carga la configuración.
+     *
+     * @throws IOException Si el archivo no se puede crear.
+     * @throws InvalidConfigurationException Si la configuración es inválida.
+     */
+    public void register() throws IOException, InvalidConfigurationException {
+        this.file = new File(plugin.getDataFolder(), fileName);
+
+        if (!this.file.exists()) {
+            plugin.saveResource(fileName, false);
+        }
+
+        this.fileConfiguration = new YamlConfiguration();
+        this.fileConfiguration.load(this.file);
+    }
+
+    /**
+     * Guarda la configuración en el archivo.
+     */
+    public void save() {
+        try {
+            this.fileConfiguration.save(this.file);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Recarga el archivo.
+     */
+    public void reload() {
+        try {
+            this.fileConfiguration.load(this.file);
+        } catch (IOException | InvalidConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public FileConfiguration getFileConfiguration() {
+        return this.fileConfiguration;
+    }
+}

--- a/1_20_core/src/main/resources/config.yml
+++ b/1_20_core/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+# Config file

--- a/1_20_core/src/main/resources/lang.yml
+++ b/1_20_core/src/main/resources/lang.yml
@@ -1,0 +1,1 @@
+# Lang file


### PR DESCRIPTION
### **Instrucciones de Uso:**
- Para agregar un nuevo archivo de configuración, simplemente agrega un nuevo valor al enum.
- El nombre de la constante del enum debe coincidir con el nombre del archivo de configuración, pero en mayusculas.

### **Ejemplo de uso:**
`ConfigFile.CONFIG.getConfig().getString("path")`

### **Posibles Problemas:**
Si se requiere agregar archivos de configuración dinámicos, el enfoque basado en enum no funcionará. En ese caso, sería necesario refactorizar la implementación.