### PR TITLE
feat: added BaseCommand class

### DIFF
--- a/1_20_core/src/main/java/com/bteconosur/core/command/BaseCommand.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/command/BaseCommand.java
@@ -49,7 +49,7 @@ public abstract class BaseCommand implements CommandExecutor {
             return false;
         }
 
-        if (args.length > 0) {
+        if (args.length > 0 && !subcommands.isEmpty()) {
             String subcommandName = args[0].toLowerCase();
             BaseCommand subcommand = subcommands.get(subcommandName);
 

--- a/1_20_core/src/main/java/com/bteconosur/core/command/BaseCommand.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/command/BaseCommand.java
@@ -1,0 +1,68 @@
+package com.bteconosur.core.command;
+
+import com.bteconosur.core.BteConoSurCore;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class BaseCommand implements CommandExecutor {
+
+    public enum CommandMode {
+        PLAYER_ONLY,
+        CONSOLE_ONLY,
+        BOTH
+    }
+
+    private final CommandMode commandMode;
+    private final String permission;
+    protected final BteConoSurCore plugin;
+
+    public BaseCommand() {
+        this(null, CommandMode.BOTH);
+    }
+
+    public BaseCommand(String permission) {
+        this(permission, CommandMode.BOTH);
+    }
+
+    public BaseCommand(String permission, CommandMode mode) {
+        this.plugin = BteConoSurCore.getPlugin();
+        this.permission = permission;
+        this.commandMode = mode;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!isAllowedSender(sender)) {
+            // Implementar mensaje de que el comando no puede ser ejecutado por ese tipo de sender.
+            return false;
+        }
+
+        if (permission != null && !sender.hasPermission(permission)) {
+            // Implementar mensaje de que el jugador no tiene permisos.
+            return false;
+        }
+
+        return execute(sender, args);
+    }
+
+    /**
+     * Verifica si el tipo de sender tiene permiso para ejecutar el comando.
+     */
+    private boolean isAllowedSender(CommandSender sender) {
+        if (commandMode == CommandMode.PLAYER_ONLY && !(sender instanceof Player)) {
+            return false;
+        }
+        if (commandMode == CommandMode.CONSOLE_ONLY && sender instanceof Player) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Método a sobrescribir para manejar la ejecución del comando.
+     */
+    protected abstract boolean execute(CommandSender sender, String[] args);
+}


### PR DESCRIPTION
## Sistema de manejo de comandos con permisos y restricciones de ejecución

Se ha implementado una nueva clase `BaseCommand` para estandarizar el manejo de comandos en el plugin.

## Cambios principales:
- Se introdujo la clase `BaseCommand` como una abstracción para los comandos.
- Se añadió el enum `CommandMode` con las opciones `PLAYER_ONLY`, `CONSOLE_ONLY` y `BOTH` para restringir qué tipo de entidad puede ejecutar el comando.
- Se mejoró la estructura del código al delegar la lógica de validación en la clase base, reduciendo la repetición de código en comandos específicos.

## Beneficios:
- Simplificación de la implementación de nuevos comandos.
- Eliminación de lógica repetitiva en la verificación de permisos y tipos de ejecutores.