### PR TITLE
refactor: BaseCommand now extends from Command

### DIFF
--- a/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
@@ -1,7 +1,7 @@
 package com.bteconosur.core;
 
 import com.bteconosur.core.config.PluginConfig;
-import com.bteconosur.core.util.PluginRegistry;
+import com.bteconosur.core.utils.PluginRegistry;
 import org.bukkit.command.CommandMap;
 import org.bukkit.plugin.java.JavaPlugin;
 

--- a/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
@@ -1,6 +1,8 @@
 package com.bteconosur.core;
 
 import com.bteconosur.core.config.PluginConfig;
+import com.bteconosur.core.utils.PluginRegistry;
+import org.bukkit.command.CommandMap;
 import org.bukkit.plugin.java.JavaPlugin;
 
 
@@ -10,6 +12,9 @@ public final class BteConoSurCore extends JavaPlugin {
     public void onEnable() {
         // Plugin startup logic
         PluginConfig.createFiles();
+
+        // Command registration
+        CommandMap commandMap = PluginRegistry.getCommandMap();
     }
 
     @Override
@@ -19,9 +24,5 @@ public final class BteConoSurCore extends JavaPlugin {
 
     public static BteConoSurCore getPlugin() {
         return JavaPlugin.getPlugin(BteConoSurCore.class);
-    }
-
-    public void disablePlugin() {
-        this.getServer().getPluginManager().disablePlugin(this);
     }
 }

--- a/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/BteConoSurCore.java
@@ -1,7 +1,7 @@
 package com.bteconosur.core;
 
 import com.bteconosur.core.config.PluginConfig;
-import com.bteconosur.core.utils.PluginRegistry;
+import com.bteconosur.core.util.PluginRegistry;
 import org.bukkit.command.CommandMap;
 import org.bukkit.plugin.java.JavaPlugin;
 

--- a/1_20_core/src/main/java/com/bteconosur/core/command/BaseCommand.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/command/BaseCommand.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BaseCommand implements CommandExecutor {
+public abstract class BaseCommand extends Command {
 
     public enum CommandMode {
         PLAYER_ONLY,
@@ -18,27 +18,30 @@ public abstract class BaseCommand implements CommandExecutor {
         BOTH
     }
 
+    private final String command;
     private final CommandMode commandMode;
     private final String permission;
     private final Map<String, BaseCommand> subcommands = new HashMap<>();
     protected final BteConoSurCore plugin;
 
-    public BaseCommand() {
-        this(null, CommandMode.BOTH);
+    public BaseCommand(String command) {
+        this(command, null, CommandMode.BOTH);
     }
 
-    public BaseCommand(String permission) {
-        this(permission, CommandMode.BOTH);
+    public BaseCommand(String command, String permission) {
+        this(command, permission, CommandMode.BOTH);
     }
 
-    public BaseCommand(String permission, CommandMode mode) {
+    public BaseCommand(String command, String permission, CommandMode mode) {
+        super(command);
+        this.command = command;
         this.plugin = BteConoSurCore.getPlugin();
         this.permission = permission;
         this.commandMode = mode;
     }
 
     @Override
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
         if (!isAllowedSender(sender)) {
             // Implementar mensaje de que el comando no puede ser ejecutado por ese tipo de sender.
             return false;
@@ -54,23 +57,23 @@ public abstract class BaseCommand implements CommandExecutor {
             BaseCommand subcommand = subcommands.get(subcommandName);
 
             if (subcommand != null) {
-                return subcommand.onCommand(sender, command, label, shiftArgs(args));
+                return subcommand.onCommand(sender, shiftArgs(args));
             }
         }
 
-        return execute(sender, args);
+        return onCommand(sender, args);
     }
 
     /**
      * Método abstracto para manejar la ejecución del comando.
      */
-    protected abstract boolean execute(CommandSender sender, String[] args);
+    protected abstract boolean onCommand(CommandSender sender, String[] args);
 
     /**
      * Agrega un subcomando a este comando.
      */
-    public void addSubcommand(String name, BaseCommand subcommand) {
-        subcommands.put(name.toLowerCase(), subcommand);
+    public void addSubcommand(BaseCommand subcommand) {
+        subcommands.put(command.toLowerCase(), subcommand);
     }
 
     private boolean isAllowedSender(CommandSender sender) {

--- a/1_20_core/src/main/java/com/bteconosur/core/util/PluginRegistry.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/util/PluginRegistry.java
@@ -1,4 +1,4 @@
-package com.bteconosur.core.utils;
+package com.bteconosur.core.util;
 
 import com.bteconosur.core.BteConoSurCore;
 import org.bukkit.Bukkit;

--- a/1_20_core/src/main/java/com/bteconosur/core/utils/PluginRegistry.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/utils/PluginRegistry.java
@@ -1,0 +1,31 @@
+package com.bteconosur.core.utils;
+
+import com.bteconosur.core.BteConoSurCore;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandMap;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class PluginRegistry {
+    /**
+     * Obtiene el CommandMap de Bukkit.
+     * @return
+     */
+    public static CommandMap getCommandMap() {
+        try {
+            return (CommandMap) Bukkit.getServer().getClass().getDeclaredMethod("getCommandMap")
+                    .invoke(Bukkit.getServer());
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            disablePlugin("Error getting bukkit command map");
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Deshabilita el plugin con un mensaje de error.
+     */
+    public static void disablePlugin(String reason) {
+        Bukkit.getLogger().severe(reason);
+        Bukkit.getServer().getPluginManager().disablePlugin(BteConoSurCore.getPlugin());
+    }
+}

--- a/1_20_core/src/main/java/com/bteconosur/core/utils/PluginRegistry.java
+++ b/1_20_core/src/main/java/com/bteconosur/core/utils/PluginRegistry.java
@@ -1,4 +1,4 @@
-package com.bteconosur.core.util;
+package com.bteconosur.core.utils;
 
 import com.bteconosur.core.BteConoSurCore;
 import org.bukkit.Bukkit;


### PR DESCRIPTION
- Creé la clase util.PluginRegistry para centralizar la gestión del plugin.
- Moví el método `disablePlugin` a `PluginRegistry` para mejorar la organización del código.
- Agregué un método en `PluginRegistry` para obtener el CommandMap de Bukkit, permitiendo registrar comandos dinámicamente sin necesidad de agregarlos en `plugin.yml`.
- Modifiqué la clase `BaseCommand` para que ahora extienda de Command.
- Añadí un argumento command al constructor de `BaseCommand` para definir el nombre del comando de manera dinámica.